### PR TITLE
Added ability to specify the offset of the partition table

### DIFF
--- a/esp32_firmware_reader.py
+++ b/esp32_firmware_reader.py
@@ -27,8 +27,8 @@ def print_verbose(verbose, value):
     if verbose:
         print(value)
 
-def read_partition_table(fh, verbose=False):
-    fh.seek(0x8000)
+def read_partition_table(fh, verbose=False, p_offset=0x8000):
+    fh.seek(p_offset)
     partition_table = {}
 
     print_verbose(verbose, "reading partition table...")

--- a/esp32_image_parser.py
+++ b/esp32_image_parser.py
@@ -6,6 +6,7 @@ import json
 import os, argparse
 from makeelf.elf import *
 from esptool import *
+from esptool.bin_image import *
 from esp32_firmware_reader import *
 from read_nvs import *
 

--- a/esp32_image_parser.py
+++ b/esp32_image_parser.py
@@ -221,6 +221,7 @@ def main():
     arg_parser.add_argument('-output', help='Output file name')
     arg_parser.add_argument('-nvs_output_type', help='output type for nvs dump', type=str, choices=["text","json"], default="text")
     arg_parser.add_argument('-partition', help='Partition name (e.g. ota_0)')
+    arg_parser.add_argument('-partition_offset', help='Set partition offset(HEX) (e.g. 0x8000)')
     arg_parser.add_argument('-v', default=False, help='Verbose output', action='store_true')
 
     args = arg_parser.parse_args()
@@ -232,7 +233,10 @@ def main():
             verbose = True
 
         # parse that ish
-        part_table = read_partition_table(fh, verbose)
+        if "partition_offset" in args:
+            args.partition_offset = int(args.partition_offset, 16)
+
+        part_table = read_partition_table(fh, verbose, p_offset=args.partition_offset)
 
         if args.action in ['dump_partition', 'create_elf', 'dump_nvs']:
             if (args.partition is None):


### PR DESCRIPTION
Recently, I found myself needing to dump a firmware with the partition table at a location different from the standard one. 
I've made a modification that allows specifying the starting position of the partition table. Additionally, I have already integrated the fixes for issue #4.