### PR TITLE
Import bin_image from esptool in esp32_image_parser

### DIFF
--- a/esp32_image_parser.py
+++ b/esp32_image_parser.py
@@ -8,6 +8,7 @@ from makeelf.elf import *
 from esptool import *
 from esp32_firmware_reader import *
 from read_nvs import *
+from esptool.bin_image import *
 
 def image_base_name(path):
     filename_w_ext = os.path.basename(path)


### PR DESCRIPTION
This caused error so I fixed it 

``` 
   Traceback (most recent call last):
  File "G:\KANPLAY_bin\esp32_image_parser\esp32_image_parser.py", line 281, in <module>
    main()
  File "G:\KANPLAY_bin\esp32_image_parser\esp32_image_parser.py", line 264, in main
    image2elf(dump_file, output_file, verbose)
  File "G:\KANPLAY_bin\esp32_image_parser\esp32_image_parser.py", line 41, in image2elf
    image = LoadFirmwareImage('esp32', filename)
NameError: name 'LoadFirmwareImage' is not defined
```